### PR TITLE
update guide.md Code generated by Wire

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -165,7 +165,7 @@ func initializeBaz(ctx context.Context) (foobarbaz.Baz, error) {
     bar := foobarbaz.ProvideBar(foo)
     baz, err := foobarbaz.ProvideBaz(ctx, bar)
     if err != nil {
-        return 0, err
+        return foobarbaz.Baz{}, err
     }
     return baz, nil
 }


### PR DESCRIPTION
should be "return foobarbaz.Baz{}, err"
